### PR TITLE
fix subfolder bug

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,9 @@ import (
 
 // TODO: add option to open expanded dif by appending ?`expand=1` at the end of the URL
 func main() {
-	repo, err := git.PlainOpen(".")
+	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{
+		DetectDotGit: true,
+	})
 	if err != nil {
 		log.Fatalf("Failed to open git repository: %v", err)
 	}

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 go test -json -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt


### PR DESCRIPTION
there was a small bug were the command would fail to detect the git repository when run from a subfolder as `git.PlainOpen(".")` would fail to detect the git repo in subfolders so I switched to use `git.PlainOpenWithOptions` passing `DetectDotGit: true` as option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced Git repository detection for improved reliability.
- **Chores**
  - Specified Bash shell for the test script execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->