### PR TITLE
ci: lint with go vet, pin Go from go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache Go modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -31,14 +31,12 @@ jobs:
             ${{ runner.os }}-go-modules-
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.23.0"
+          go-version-file: "go.mod"
 
-      - name: Lint with golangci-lint-action
-        uses: golangci/golangci-lint-action@v4
-        with:
-          version: latest
+      - name: Vet
+        run: go vet ./...
 
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
## Why

Every PR (including Dependabot #20) has been failing its `build` check — but not because of the change. The **lint step** dies with:

> can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)

`golangci-lint-action@v4 + version: latest` installs a linter built on go1.24, which refuses to lint a module targeting **go 1.25**, and `setup-go` was pinned to a stale **1.23.0**.

## What

- Replace the `golangci-lint` step with **`go vet ./...`** — matches the `make lint` command documented in the Makefile/AGENTS.md, and removes the linter-vs-Go-version treadmill.
- Read the Go version from **`go.mod`** (`go-version-file`) so it can't drift again.
- Bump deprecated `actions/cache@v3` → `v4`.

## Verified locally (go1.25.0)

`go build`, `go test -race`, and `go vet` all pass.

Unblocks #20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go build and test workflow to use newer automation actions and follow the Go version from the project configuration.
  * Added an extra Go validation step to catch issues earlier during checks.
  * Removed one linter step from the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->