### PR TITLE
refactor: extract remote name into a package-level const

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 	"github.com/go-git/go-git/v5"
 )
 
+const defaultRemoteName = "origin"
+
 // TODO: add option to open expanded dif by appending ?`expand=1` at the end of the URL
 func main() {
 	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{
@@ -24,10 +26,9 @@ func main() {
 		log.Fatalf("Failed to open git repository: %v", err)
 	}
 
-	remoteName := "origin"
-	remote, err := repo.Remote(remoteName)
+	remote, err := repo.Remote(defaultRemoteName)
 	if err != nil {
-		log.Fatalf("Failed to get remote '%s': %v", remoteName, err)
+		log.Fatalf("Failed to get remote '%s': %v", defaultRemoteName, err)
 	}
 
 	remoteURL := remote.Config().URLs[0]


### PR DESCRIPTION
Promotes the hardcoded `"origin"` from a local variable inside `main()` to a package-level `const defaultRemoteName`.

Pure refactor, zero behaviour change:
- The compiler now guarantees the remote name can't be reassigned.
- Single source of truth, ready to become the default value of a future `--remote` flag.

Verified locally: `go build`, `go vet`, `go test` all pass.

First of the r/golang cleanup items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized the default Git remote name in the app, improving consistency in remote lookup and related error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->