### PR TITLE
refactor: use if-scoped err for the openBrowser call

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,8 +46,8 @@ func main() {
 	newPRURL := fmt.Sprintf("%s/compare/%s", githubURL, url.PathEscape(currentBranch))
 
 	fmt.Printf("Opening: %s\n", newPRURL)
-	err = openBrowser(newPRURL)
-	if err != nil {
+
+	if err := openBrowser(newPRURL); err != nil {
 		log.Fatalf("Failed to open browser: %v", err)
 	}
 }


### PR DESCRIPTION
Folds the final `openBrowser` call into an `if`-scoped error check:

```go
if err := openBrowser(newPRURL); err != nil {
    log.Fatalf("Failed to open browser: %v", err)
}
```

`openBrowser` returns only an `error` (no value needed afterward), so scoping `err` to the `if` block is safe and idiomatic — it shrinks the variable's lifetime to exactly where it's used. The other error checks in `main()` keep `:=` at function scope because they bind a value (`remote`, `headRef`, …) that later lines depend on.

Pure refactor, zero behaviour change. Verified: gofmt clean, `go vet`, `go test` all pass.

Second of the r/golang cleanup items.