### PR TITLE
build: gate lint on gofmt and enforce it in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           go-version-file: "go.mod"
 
-      - name: Vet
-        run: go vet ./...
+      - name: Lint (gofmt check + go vet)
+        run: make lint
 
       - name: Build
         run: go build -v ./...

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,14 @@ menu:
 	@printf "  $(BOLD)$(GREEN)=== Testing ===$(RESET)\n"
 	@printf "   $(YELLOW)4)$(RESET)  make test             $(DIM)Run all tests$(RESET)\n"
 	@printf "   $(YELLOW)5)$(RESET)  make test-verbose     $(DIM)Run tests with verbose output$(RESET)\n"
-	@printf "   $(YELLOW)6)$(RESET)  make lint             $(DIM)Run go vet$(RESET)\n"
+	@printf "\n"
+	@printf "  $(BOLD)$(GREEN)=== Code Quality ===$(RESET)\n"
+	@printf "   $(YELLOW)6)$(RESET)  make fmt              $(DIM)Format code with gofmt$(RESET)\n"
+	@printf "   $(YELLOW)7)$(RESET)  make lint             $(DIM)Check formatting + go vet$(RESET)\n"
 	@printf "\n"
 	@printf "  $(BOLD)$(GREEN)=== Maintenance ===$(RESET)\n"
-	@printf "   $(YELLOW)7)$(RESET)  make clean            $(DIM)Remove build artifacts$(RESET)\n"
-	@printf "   $(YELLOW)8)$(RESET)  make tidy             $(DIM)Tidy Go modules$(RESET)\n"
+	@printf "   $(YELLOW)8)$(RESET)  make clean            $(DIM)Remove build artifacts$(RESET)\n"
+	@printf "   $(YELLOW)9)$(RESET)  make tidy             $(DIM)Tidy Go modules$(RESET)\n"
 	@printf "\n"
 	@read -p "  Enter choice: " choice; \
 	case $$choice in \
@@ -38,9 +41,10 @@ menu:
 		3) $(MAKE) run ;; \
 		4) $(MAKE) test ;; \
 		5) $(MAKE) test-verbose ;; \
-		6) $(MAKE) lint ;; \
-		7) $(MAKE) clean ;; \
-		8) $(MAKE) tidy ;; \
+		6) $(MAKE) fmt ;; \
+		7) $(MAKE) lint ;; \
+		8) $(MAKE) clean ;; \
+		9) $(MAKE) tidy ;; \
 		*) echo "Invalid choice" ;; \
 	esac
 
@@ -59,7 +63,17 @@ test:
 test-verbose:
 	$(GO) test -v ./...
 
-lint:
+fmt:
+	gofmt -w .
+
+fmt-check:
+	@if [ -n "$$(gofmt -l .)" ]; then \
+		echo "These files need formatting (run 'make fmt'):"; \
+		gofmt -l .; \
+		exit 1; \
+	fi
+
+lint: fmt-check
 	$(GO) vet ./...
 
 clean:
@@ -78,11 +92,13 @@ help:
 	@printf "  $(CYAN)make run$(RESET)           Run with go run\n"
 	@printf "  $(CYAN)make test$(RESET)          Run all tests\n"
 	@printf "  $(CYAN)make test-verbose$(RESET)  Run tests with verbose output\n"
-	@printf "  $(CYAN)make lint$(RESET)          Run go vet\n"
+	@printf "  $(CYAN)make fmt$(RESET)           Format code with gofmt\n"
+	@printf "  $(CYAN)make fmt-check$(RESET)     Check formatting (fails if unformatted)\n"
+	@printf "  $(CYAN)make lint$(RESET)          Check formatting + go vet\n"
 	@printf "  $(CYAN)make clean$(RESET)         Remove build artifacts\n"
 	@printf "  $(CYAN)make tidy$(RESET)          Tidy Go modules\n"
 	@printf "\n"
 
 list: help
 
-.PHONY: menu build install run test test-verbose lint clean tidy help list
+.PHONY: menu build install run test test-verbose fmt fmt-check lint clean tidy help list


### PR DESCRIPTION
## Problem

`make lint` ran `go vet` only, and CI ran raw `go vet` too — so unformatted code (a stray trailing tab, etc.) passed **both** local lint and the pipeline.

## Change

- **`fmt`** — `gofmt -w .` (fixer).
- **`fmt-check`** — fails (exit 1) if `gofmt -l .` reports any file, printing the offenders + a "run `make fmt`" hint. Reusable gate.
- **`lint: fmt-check`** — one command covers formatting *and* vet.
- **CI runs `make lint`** instead of raw `go vet`, so the pipeline enforces the same gofmt gate as local. The Makefile is now the single source of truth. Build/Test stay explicit in CI (they keep `-race` and coverage).
- Menu / help / `.PHONY` kept in sync (new "Code Quality" group).

## Verified locally

- `make lint` passes on clean code.
- Injecting bad formatting makes `make lint` **fail** (exit 2) with the offender listed — the gate bites.
- `make fmt` fixes it; build + tests unaffected.

This time CI itself runs the gate, so the check is enforced, not just available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new formatting commands to make it easier to keep Go code standardized.
  * Added a new help/list view and updated the menu options to include the latest quality-related commands.

* **Bug Fixes**
  * The lint workflow now checks formatting before running Go vet, helping catch style issues earlier.
  * CI linting now uses the combined quality check instead of only running vet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->